### PR TITLE
Title link visible on posts overview and each post links to 404 error page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header class="site-header px2 px-responsive">
   <div class="mt2 wrap">
     <div class="measure">
-      <a href="{{ site.url }}">{{ site.title }}</a>
+      <a href="{{ site.url | append: site.baseurl }}">{{ site.title }}</a>
       <nav class="site-nav right">
         {% include navigation.html %}
       </nav>


### PR DESCRIPTION
Currently the title link in the header of each page of the blog links to
https://anholt.github.io which is not the top-level of the blog and
actually displays a 404 error page.

This change should make the title link point to https://anholt.github.io/twivc4
which is the expected action.

I didn't test this patch nor do I have experience in using jekyll, but the change seemed
straight-forward.